### PR TITLE
fix: specify DEFAULT-DIRECTORY for when calling expand-file-name

### DIFF
--- a/citre.el
+++ b/citre.el
@@ -625,7 +625,9 @@ and `citre-get-field' are the 2 main APIs that interactive
 commands should use, and ideally should only use."
   (let ((tags-file (cl-some
                     (lambda (file)
-                      (let ((tags-file (expand-file-name file project)))
+                      (let ((tags-file (expand-file-name file
+                                                         (or project
+                                                             (citre--project-root)))))
                         (when (file-exists-p tags-file) tags-file)))
                     citre-tags-files)))
     (unless tags-file


### PR DESCRIPTION
expand-file-name called in citre-get-records didn't work well when
PROJECT is nil; PROJECT is passed to expand-file-name as an argument
for DEFAULT-DIRECTORY parameter.

This change specifies the value returned from (citre--project-root) as
the fallback value.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>