### PR TITLE
fix: don't eval project root during macroexpand

### DIFF
--- a/citre-map.el
+++ b/citre-map.el
@@ -145,7 +145,7 @@ If project root PROJECT is given, use that project instead.
 Notice: Since this is a macro, the arguments are considered to be
 non-nil as long as a form that is non-nil is presented, even when
 its value is nil."
-  (let* ((project (or project (citre--project-root))))
+  (let* ((project (or project '(citre--project-root))))
     (if file
         (if symbol
             `(alist-get ,symbol (citre--get-in-code-map ,file nil ,project)
@@ -162,7 +162,7 @@ If project root PROJECT is given, use that project instead.
 Notice: Since this is a macro, the arguments are considered to be
 non-nil as long as a form that is non-nil is presented, even when
 its value is nil."
-  (let ((project (or project (citre--project-root))))
+  (let ((project (or project '(citre--project-root))))
     `(alist-get ,project citre--code-map-position-alist
                 nil nil #'equal)))
 


### PR DESCRIPTION
Seems to be a classical mistake ;) See https://www.gnu.org/software/emacs/manual/html_node/elisp/Wrong-Time.html

@masatake Please test this PR when you have time. And, it would be great if you could look into the macros and see if there are other problems. I'm really not good at macros.

I tested it and it works, no matter I require `citre-map` in init.el, or eval the buffer `citre-map.el` (see https://github.com/AmaiKinono/citre/issues/3#issuecomment-616940507, these causes different behaviors before), then browsing the code map of any project.