### PR TITLE
fix: fix the toggle behavior of citre-peek

### DIFF
--- a/citre-peek.el
+++ b/citre-peek.el
@@ -1260,7 +1260,8 @@ When BUF or POINT is nil, it's set to the current buffer and
 point."
   (interactive)
   (when citre-peek--mode
-    (citre-peek-abort))
+    (citre-peek-abort)
+    (cl-return))
   (let* ((buf (or buf (current-buffer)))
          (point (or point (point)))
          (tagsfile (with-current-buffer buf


### PR DESCRIPTION
Though `citre-peek` called `citre-peek-abort`, it had no effect.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>