### PR TITLE
feat: GNU Global plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
       - name: '[dep] Check if download failed'
         if: steps.cache.outputs.cache-hit != 'true'
         run: exit 1
+      - name: '[dep] Install GNU Global'
+        run: sudo apt-get install global
       - name: '[dep] Install Emacs'
         uses: purcell/setup-emacs@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.1.x
+## 0.2 (released 2021-09-27)
+
+### Features
+
+- `citre-global` is a GNU Global plugin that can find references using xref, or
+  UI similar to `citre-jump` and `citre-peek`.
 
 ### 0.1.3 (released 2021-09-27)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Let's see them in action!
 All above screenshots were taken in a huge project (the Linux kernel), and
 Citre is still fast, because readtags performes binary search on the tags file.
 
+Besides, Citre has a GNU Global plugin that can find references using xref or
+the above UIs. See [this user manual](docs/user-manual/citre-global.md) to know
+about it.
+
 ## Quick start
 
 ### Prerequisites
@@ -390,6 +394,7 @@ Below are the status of tools provided by Citre:
 | capf, xref, imenu | Integration with built-in mechanisms | stable |      |
 | `citre-jump`      | Jump to the definition               | stable |      |
 | `citre-peek`      | Deep code reading in a peek window   | beta   | [^2] |
+| `citre-global`    | GNU Global plugin                    | alpha  |      |
 
 [^1]: Universal Ctags is exploring concepts like [incremental
       updating](https://github.com/universal-ctags/ctags/issues/2697),

--- a/citre-global.el
+++ b/citre-global.el
@@ -1,0 +1,351 @@
+;;; citre-global.el --- Finding references using GNU Global in Citre -*- lexical-binding:t -*-
+
+;; Copyright (C) 2021 Hao Wang
+
+;; Author: Hao Wang <amaikinono@gmail.com>
+;; Maintainer: Hao Wang <amaikinono@gmail.com>
+;; Created: 24 Sep 2021
+;; Keywords: convenience, tools
+;; Homepage: https://github.com/universal-ctags/citre
+;; Version: 0.1.3
+;; Package-Requires: ((emacs "26.1"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; citre-global is a GNU Global plugin for citre.  It offers commands to create
+;; & update gtags database, commands similar to `citre-jump', `citre-peek' to
+;; find references of a symbol using Global, and `xref-find-references'
+;; integration.
+
+;; Read the following doc to know how to use citre-peek:
+;;
+;; - docs/user-manual/citre-global.md
+
+;; If you haven't received the doc, please visit
+;; https://github.com/universal-ctags/citre.
+
+;;; Code:
+
+;; To see the outline of this file, run M-x outline-minor-mode and
+;; then press C-c @ C-t. To also show the top-level functions and
+;; variable declarations in each section, run M-x occur with the
+;; following query: ^;;;;* \|^(
+
+;;;; Libraries
+
+(require 'citre-basic-tools)
+(require 'citre-peek)
+(require 'citre-util)
+
+(defcustom citre-gtags-program nil
+  "The name or path of the gtags program.
+Set this if gtags is not in your PATH, or its name is not
+\"gtags\"."
+  :type '(set string (const nil))
+  :group 'citre)
+
+(defcustom citre-global-program nil
+  "The name or path of the GNU Global program.
+Set this if global is not in your PATH, or its name is not
+\"global\"."
+  :type '(set string (const nil))
+  :group 'citre)
+
+;;;; Global program interface
+
+;;;;; Internals
+
+(defvar citre-global--find-references-args
+  '("--color=never"
+    "--encode-path= :"
+    "--result=grep"
+    "--literal"
+    "--reference"
+    "--symbol")
+  "Arguments used for finding references using global.
+`citre-global--get-reference-lines' may add more arguments on
+these.")
+
+;; TODO: Make this a general API.
+(defun citre-global--get-output-lines (args)
+  "Get output from global program.
+ARGS is the arguments passed to the program.
+
+This is designed to allow local quit to terminate the process."
+  ;; The implementation of this function is similar to `citre-core--get-lines'.
+  (let* ((output-buf (get-buffer-create " *citre-global*"))
+         inhibit-message
+         proc exit-msg)
+    (with-current-buffer output-buf
+      (erase-buffer))
+    (when (file-remote-p default-directory)
+      (setq inhibit-message t))
+    (let ((inhibit-quit t))
+      (pcase (with-local-quit
+               (catch 'citre-done
+                 (setq proc
+                       (make-process
+                        :name "global"
+                        :buffer output-buf
+                        :command (append (list
+                                          (or citre-global-program "global"))
+                                         args)
+                        :connection-type 'pipe
+                        :stderr nil
+                        :sentinel (lambda (_proc _msg)
+                                    (throw 'citre-done t))
+                        :file-handler t))
+                 (while (sleep-for 30))))
+        ('nil (set-process-sentinel proc #'ignore)
+              (if (eq system-type 'windows-nt)
+                  (signal-process proc 'sighup)
+                (interrupt-process proc))
+              nil)
+        (_ (pcase (process-status proc)
+             ('exit
+              (pcase (process-exit-status proc)
+                (0 nil)
+                (s (setq exit-msg (format "global exits %s\n" s)))))
+             (s (setq exit-msg
+                      (format "abnormal status of global: %s\n" s))))
+           (let ((output (with-current-buffer output-buf (buffer-string))))
+             (if exit-msg
+                 (error (concat exit-msg output))
+               (split-string output "\n" t))))))))
+
+(defun citre-global--get-reference-lines (name &optional case-fold)
+  "Find references to NAME using global and return the outputed lines.
+When CASE-FOLD is non-nil, do case-insensitive matching."
+  (let* ((name (when name (substring-no-properties name)))
+         inhibit-message
+         args)
+    (when case-fold (push "--ignore-case" args))
+    (setq args (append args citre-global--find-references-args
+                       (list "--" name)))
+    (citre-global--get-output-lines args )))
+
+(defun citre-global--read-path (path)
+  "Translate escaped sequences in PATH.
+The path should come from the output of global, with the
+\"--encode-path\" option."
+  (let ((last 0)
+        (i nil)
+        (parts nil))
+    (while (setq i (string-match "%" path last))
+      (push (substring path last i) parts)
+      (push (char-to-string (string-to-number
+                             (substring path (1+ i) (+ 3 i))
+                             16))
+            parts)
+      (setq last (+ 3 i)))
+    (push (substring path last) parts)
+    (apply #'concat (nreverse parts))))
+
+(defun citre-global--parse-line (line rootdir &optional name)
+  "Parse a LINE in the output of global.
+ROOTDIR is the working directory when running the global command.
+The return value is a tag contains `ext-abspath', `line', and
+`extras' field.  If NAME is given, is used as the `name' field.
+The value of `extras' field is \"reference\"."
+  (if (string-match (rx line-start
+                        (group-n 1 (+ (not (any ":"))))
+                        ":"
+                        (group-n 2 (+ num))
+                        ":")
+                    line)
+      (let ((path (match-string 1 line))
+            (linum (match-string 2 line))
+            (tag (make-hash-table :test #'eq)))
+        ;; We don't record the pattern field since it's generate in real time,
+        ;; so it can't be used to deal with file updates.
+        (setq path (expand-file-name (citre-global--read-path path) rootdir))
+        (when name (puthash 'name (substring-no-properties name) tag))
+        (puthash 'ext-abspath path tag)
+        (puthash 'line linum tag)
+        (puthash 'extras "reference" tag)
+        tag)
+    (error "Invalid LINE")))
+
+;;;;; API
+
+(defun citre-global-get-references (&optional name case-fold)
+  "Get reference tags using global.
+When NAME is non-nil, get references of NAME, otherwise get
+references of the symbol under point.
+
+When CASE-FOLD is non-nil, do case-insensitive matching.
+
+Global program is run under current `default-directory'."
+  (let ((name (or name (citre-get-symbol))))
+    (mapcar (lambda (line)
+              (citre-global--parse-line line default-directory name))
+            (citre-global--get-reference-lines name case-fold))))
+
+;;;; Tags file generating & updating
+
+;;;;; Commands
+
+;;;###autoload
+(defun citre-global-create-database ()
+  "Create gtags database."
+  (interactive)
+  (let* ((project (funcall citre-project-root-function))
+         (default-directory
+           (or (and citre-use-project-root-when-creating-tags
+                    project)
+               (read-directory-name
+                "I want to tag this dir using gtags: "
+                project))))
+    (make-process
+     :name "gtags"
+     :buffer (get-buffer-create "*citre-gtags*")
+     :command (list (or citre-gtags-program "gtags")
+                    "--compact"
+                    "--objdir")
+     :connection-type 'pipe
+     :stderr nil
+     :sentinel
+     (lambda (proc _msg)
+       (pcase (process-status proc)
+         ('exit
+          (pcase (process-exit-status proc)
+            (0 (message "Finished tagging"))
+            (s (user-error "Gtags exits %s.  See *citre-gtags* buffer" s))))
+         (s (user-error "Abnormal status of gtags: %s.  \
+See *citre-ctags* buffer" s))))
+     :file-handler t)
+    (message "Tagging...")))
+
+;;;###autoload
+(defun citre-global-update-database ()
+  "Update the gtags database in use."
+  (interactive)
+  (let ((prog (or citre-global-program "global")))
+    (make-process
+     :name "global"
+     :buffer (get-buffer-create "*citre-global-update*")
+     :command (list (or citre-global-program "global")
+                    "--update")
+     :connection-type 'pipe
+     :stderr nil
+     :sentinel
+     (lambda (proc _msg)
+       (pcase (process-status proc)
+         ('exit
+          (pcase (process-exit-status proc)
+            (0 (message "Finished updating"))
+            (_ (if (executable-find prog)
+                   (when (y-or-n-p "Can't find database.  Create one? ")
+                     (citre-global-create-database))
+                 (user-error "Can't find global program")))))
+         (s (user-error "Abnormal status of global: %s.  \
+See *citre-global-update* buffer" s))))
+     :file-handler t)
+    (message "Updating...")))
+
+;;;; `citre-jump' equivalent
+
+;;;###autoload
+(defun citre-jump-to-reference ()
+  "Jump to the reference of the symbol at point.
+This uses the `citre-jump' UI."
+  (interactive)
+  (let* ((marker (point-marker))
+         (symbol (citre-get-symbol))
+         (references
+          (citre-global-get-references symbol))
+         (root (funcall citre-project-root-function)))
+    (when (null references)
+      (user-error "Can't find references for %s" symbol))
+    (citre-jump-show symbol references marker root)))
+
+;;;; `citre-peek' equivalent
+
+;;;;; Internals
+
+(defun citre-global--peek-get-symbol-and-references ()
+  "Return the symbol under point and references of it.
+This is similar to `citre-peek--get-symbol-and-definitions'."
+  (citre-peek--hack-buffer-file-name
+    (let* ((symbol (or (citre-get-symbol)
+                       (user-error "No symbol at point")))
+           (references (or (citre-global-get-references symbol)
+                           (user-error "Can't find references for %s"
+                                       symbol))))
+      (cons symbol references))))
+
+;;;;; Commands
+
+;;;###autoload
+(defun citre-peek-references (&optional buf point)
+  "Peek the references of the symbol in BUF and POINT.
+When BUF or POINT is nil, it's set to the current buffer and
+point."
+  (interactive)
+  (let* ((buf (or buf (current-buffer)))
+         (point (or point (point)))
+         (symbol-refs (save-excursion
+                        (with-current-buffer buf
+                          (goto-char point)
+                          (citre-global--peek-get-symbol-and-references))))
+         (marker (if (buffer-file-name) (point-marker))))
+    (citre-peek-show (car symbol-refs) (cdr symbol-refs) marker)))
+
+;;;###autoload
+(defun citre-ace-peek-references ()
+  "Peek the references of a symbol on screen using ace jump.
+This is similar to `citre-ace-peek'."
+  (interactive)
+  (when-let ((pt (citre-ace-pick-point)))
+    (citre-peek-references (current-buffer) pt)))
+
+;;;###autoload
+(defun citre-peek-through-references ()
+  "Peek through a symbol in current peek window for its references."
+  (interactive)
+  (when-let* ((buffer-point (citre-ace-pick-point-in-peek-window))
+              (symbol-defs
+               (save-excursion
+                 (with-current-buffer (car buffer-point)
+                   (goto-char (cdr buffer-point))
+                   (citre-global--peek-get-symbol-and-references)))))
+    (citre-peek-make-current-def-first)
+    (citre-peek--make-branch (car symbol-defs) (cdr symbol-defs))))
+
+;;;; `xref-find-references' integration
+
+(defun citre-xref--global-find-reference (symbol)
+  "Return the xref object of references of SYMBOL."
+  (mapcar #'citre-xref--make-object
+          (citre-global-get-references symbol)))
+
+(cl-defmethod xref-backend-references ((_backend (eql citre)) symbol)
+  "Define method for xref to find reference of SYMBOL."
+  (citre-xref--global-find-reference symbol))
+
+(provide 'citre-global)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; outline-regexp: ";;;;* "
+;; fill-column: 79
+;; emacs-lisp-docstring-fill-column: 65
+;; sentence-end-double-space: t
+;; End:
+
+;;; citre-global.el ends here

--- a/docs/user-manual/citre-global.md
+++ b/docs/user-manual/citre-global.md
@@ -1,0 +1,237 @@
+# How To Use `citre-global`
+
+`citre-global` is a GNU Global plugin for Citre. With `citre-global`, you can
+find the references of a symbol using xref or UI similar to `citre-jump` and
+`citre-peek`.
+
+## Prerequisite
+
+You need to install GNU Global. In most distributions its package name is
+"global", and should contain "gtags" and "global" program.
+
+The built-in parser of GNU Global supports C, Yacc, Java, PHP4 and assembly. By
+using the Pygments plugin parser, Global supports finding references of 150+
+languages. To use the Pygments plugin parser, you need:
+
+- Python (>=2.6. 3.x are also supported)
+- Pygments. Check if it's installed properly by `$ python -m pygments -h`. This
+  should print the help message of Pygments.
+- Ctags. The documentation requires Exuberant Ctags, but Universal Ctags could
+  do the work (and should be better).
+
+For latest information, see `plugin-factory/PLUGIN_HOWTO.pygments` in the GNU
+Global source tree.
+
+### Configuration
+
+By default, gtags creates database in the working directory. If you want to
+save them using a global cache directory, do this:
+
+```sh
+# Set this to save gtags database to GTAGSOBJDIRPREFIX/<project-root>.  This
+# requires --objdir option in gtags command line, see citre-global-gtags-args.
+export GTAGSOBJDIRPREFIX=~/.cache/gtags/
+```
+
+Notice that `GTAGSOBJDIRPREFIX` *must exist* for `gtags` to use it. So you need
+to run:
+
+```console
+$ mkdir -p ~/.cache/gtags/
+```
+
+If you want to use the Pygments plugin parser, you need the following config:
+
+```sh
+# Make sure you use the path to the default config file on your machine.  This
+# file contains the definition for Pygments plugin parser.
+export GTAGSCONF=/usr/share/gtags/gtags.conf
+export GTAGSLABEL=pygments
+```
+
+Put these in your preferred shell initialization file, like `~/.profile` or
+`~/.bashrc`.
+
+### Test
+
+Let's move to an empty directory. Create `test.c` with the following content:
+
+```c
+#include <stdio.h>
+
+static void f() {
+  printf("Hello, world!\n");
+}
+
+int main() {
+  f();
+  return 0;
+}
+```
+
+Let's generate the database with `--explain` option. If you are using Pygments
+plugin parser, you should see output similar to:
+
+```console
+$ gtags --explain
+ ...
+ - File 'test.c' is handled as follows:
+        ...
+        parser:   |parser|
+        library:  |/usr/lib/gtags/pygments-parser.so|
+ ...
+```
+
+Let's see if we could find the definition of and references to `f`:
+
+```console
+$ global -x f
+f                   3 test.c           static void f() {
+$ global -xr f
+f                   8 test.c             f();
+```
+
+If all works as expected, you now have an working GNU Global installation that
+handles references.
+
+## Configure `citre-global`
+
+Requiring `citre-global` and you are good to go:
+
+```elisp
+(require 'citre-global)
+```
+
+Here's an `use-package` config example:
+
+```elisp
+(use-package citre-global
+  :ensure nil
+  :defer t
+  :init
+  (global-set-key (kbd "C-x c r") 'citre-jump-to-reference)
+  (global-set-key (kbd "C-x c P") 'citre-ace-peek-references)
+  (global-set-key (kbd "C-x c U") 'citre-global-update-database)
+  (with-eval-after-load 'citre-peek
+    (define-key citre-peek-keymap (kbd "M-l r")
+      'citre-peek-through-references)))
+```
+
+This lazy-loads `citre-global`, meaning it will load `citre-global` only after
+you use any command in it. But since `xref-find-references` is not a command
+defined in `citre-global`, calling it won't load `citre-global`. One way to
+deal with this is:
+
+```elisp
+(use-package citre-global
+  :ensure nil
+  :defer t
+  :init
+  (add-hook 'citre-mode-hook
+            (defun require-citre-global ()
+              (require 'citre-global)
+              (remove-hook 'citre-mode-hook #'require-citre-global)))
+  ;; ...the rest of the init block...
+  )
+```
+
+This still lazy-loads `citre-global`, plus when `citre-mode` is called (to
+enable the Citre xref backend), `citre-global` is loaded.
+
+## Tagging the source tree
+
+Open any file or directory in your project. Type `M-x
+citre-global-update-database`. If no gtags database is avaliable, it will guide
+you to create one using gtags, otherwise it will update the existing one, and
+it's done incrementally.
+
+You could also use `citre-global-create-database` to create the database.
+
+## Use `citre-global`
+
+`citre-global` offers `citre-jump-to-reference`, which reuses the `citre-jump`
+UI.
+
+`citre-global` also defines method to find references for the Citre xref
+backend. So with `citre-mode` being enabled, you can use
+`xref-find-references`.
+
+`citre-global` offers commands that reuse the `citre-peek` UI:
+
+- `citre-peek-references`, equivalent to `citre-peek`;
+- `citre-ace-peek-references`, equivalent to `citre-ace-peek`;
+- `citre-peek-through-references`, equivalent to `citre-peek-through`.
+
+## Tips for using global/gtags program
+
+Though Citre handles this for you, you may still want to know how to use
+global/gtags program in the command line, to understand how everything works,
+and for debugging purpose.
+
+The `gtags` program is used to tag the project in the working directory. Citre
+uses the following options:
+
+- `--compact`: to use compact format for the tags file.
+- `--objdir`: to use the `GTAGSOBJDIRPREFIX` variable.
+
+Once the tags file is created, you can use
+
+```console
+$ global --update
+```
+
+to update the tags file incrementally. This works in any directory under the
+project root.
+
+To find the reference of a symbol, Citre internally runs:
+
+```console
+$ global --color=never --encode-path=' :' --result=grep --literal --reference \
+> --symbol -- <symbol-name>
+```
+
+This also works in any directory under the project root. The meanings of some
+of the arguments are:
+
+- `--encode-path=' :'`: Escape spaces and colons in the path. This is for
+  making the output machine-readable.
+- `--result=grep`: Use grep output format.
+- `--literal`: <symbol-name> is a literal string, not a regexp pattern.
+- `--reference`: Find the references to <symbol-name>
+- `--symbol`: Find the references even if <symbol-name> is not defined.
+
+The following command prints the path containing the tags files:
+
+```console
+$ global --print-dbpath
+```
+
+The following command prints the project root path:
+
+```console
+$ global --print-dbpath --rootdir
+```
+
+## More tips on configuring GNU Global
+
+You can copy the default config to your home directory and customize it, see
+the manpage gtags.conf(5). You may want to customize the rule for ignoring
+files when tagging, then you need to modify this part:
+
+```conf
+common:\
+	:skip=HTML/,HTML.pub/,tags,...
+```
+
+If you don't have ctags in the standard path (`/usr/bin/ctags`), you need to
+modify this part:
+
+```conf
+pygments-parser|Pygments plug-in parser:\
+	:tc=common:\
+	:ctagscom=/path/to/ctags:\
+```
+
+The default config also contains a label "native-pygments". This uses GNU
+Global built-in parser for its supported languages, and use Pygments plugin
+parser for other languages. To use this, set `GTAGSLABEL` to `native-pygments`.

--- a/docs/user-manual/compare-with-other-tools.md
+++ b/docs/user-manual/compare-with-other-tools.md
@@ -100,6 +100,9 @@ Advantages of gtags:
   issue](https://github.com/universal-ctags/ctags/issues/2697) to know the
   progress of Universal Ctags on incremental updating).
 
+Citre has a GNU Global plugin for finding references. See [How to Use
+`citre-global`](citre-global.md).
+
 ## Citre & Ctags vs. intelligent tools
 
 By "intelligent tools", we mean language servers, rtags, etc.

--- a/docs/user-manual/toc.md
+++ b/docs/user-manual/toc.md
@@ -4,3 +4,4 @@
 - [About Tags File, and How to Create One](about-tags-file.md)
 - [Customization](customization.md)
 - [Comparison of Citre & Ctags with other tools](compare-with-other-tools.md)
+- [How to Use `citre-global`](citre-global.md)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,9 +6,9 @@
 . "./scripts/common.sh"
 ITEM="test"
 
-PRELOAD="citre-common.el citre-core-tables.el citre-core.el citre-util.el \
-citre-ctags.el citre-basic-tools.el citre-peek.el citre-lang-c.el
-citre-lang-fileref.el citre.el citre-config.el"
+PRELOAD="citre-common.el citre-core-tables.el citre-core.el citre-util.el
+citre-ctags.el citre-basic-tools.el citre-peek.el citre-global.el
+citre-lang-c.el citre-lang-fileref.el citre.el citre-config.el"
 
 d=$(pwd)
 preload_options=

--- a/tests/citre-global/src.list
+++ b/tests/citre-global/src.list
@@ -1,0 +1,1 @@
+src/test.c

--- a/tests/citre-global/src/test.c
+++ b/tests/citre-global/src/test.c
@@ -1,0 +1,11 @@
+int func() {
+  return 0;
+}
+
+int ref1() {
+  return func();
+}
+
+int main() {
+  return func();
+}

--- a/tests/citre-global/test.el
+++ b/tests/citre-global/test.el
@@ -1,0 +1,34 @@
+(defmacro with-clean-global-envs (&rest body)
+  "Run BODY with some GNU Global related environment variables bind to nil.
+These variables deal with configuration file path, database path,
+etc.  See the implementation for details.  Normally you should
+wrap `citre-global' tests in this macro."
+  (declare (indent 0))
+  `(let ((process-environment-orig process-environment))
+     (unwind-protect
+         (progn
+           (setenv "GTAGSCONF" nil)
+           (setenv "GTAGSLABEL" nil)
+           (setenv "GTAGSOBJDIR" nil)
+           (setenv "MAKEOBJDIR" nil)
+           (setenv "GTAGSOBJDIRPREFIX" nil)
+           (setenv "MAKEOBJDIRPREFIX" nil)
+           ,@body)
+       (setq process-environment process-environment-orig))))
+
+(ert-deftest test-global-get-references ()
+  "Test `citre-global-get-references'."
+  (with-clean-global-envs
+    (unless (eq (call-process (or citre-gtags-program "gtags")
+                              nil "*gtags*" nil
+                              "--compact"
+                              "--file=src.list")
+                0)
+      (error "gtags failed to run:\n%s" (buffer-string "*gtags*")))
+    (let ((refs (citre-global-get-references "func")))
+      (should (equal (map-get-field 'name refs)
+                     '("func" "func")))
+      (should (equal (map-get-field 'line refs)
+                     '(6 10))))
+    (dolist (f '("GPATH" "GTAGS" "GRTAGS"))
+      (delete-file f))))


### PR DESCRIPTION
`citre-global` is a GNU Global plugin that can find references using xref, or UI similar to `citre-jump` and `citre-peek`.