### PR TITLE
C,enh: consider language: field of tags when sorting labels for goto

### DIFF
--- a/citre-lang-c.el
+++ b/citre-lang-c.el
@@ -168,7 +168,11 @@
         (citre-core-sorter
          (citre-sorter-arg-put-kinds-above '("function" "macro"))))
        ('goto
-        (citre-core-sorter (citre-sorter-arg-put-kinds-above '("label"))))
+        (citre-core-sorter (citre-sorter-arg-put-kinds-above '("label"))
+                           ;; Asm parser defines "label" kind, too.
+                           ;; By default, ctags deals .h files as C++ input.
+                           `(filter ,(citre-core-filter-lang "C") +)
+                           `(filter ,(citre-core-filter-lang "C++") +)))
        ((and (or 'struct 'union 'enum)
              keyword)
         ;; If a symbol comes after keywords "struct", "union", or "enum",

--- a/tests/ctags-lang-c/src/dummy.S
+++ b/tests/ctags-lang-c/src/dummy.S
@@ -1,0 +1,2 @@
+found:
+	call func

--- a/tests/ctags-lang-c/target.tags
+++ b/tests/ctags-lang-c/target.tags
@@ -20,6 +20,7 @@ device::minor	src/dev.h	/^  unsigned int minor;$/;"	kind:member	line:11	language
 device::name	src/dev.h	/^  const char *name;$/;"	kind:member	line:9	language:C++	scope:struct:device	typeref:typename:const char *	access:public	roles:def	extras:qualified	end:9
 find	src/find-found.c	/^void find(const char *what)$/;"	kind:function	line:1	language:C	typeref:typename:void	signature:(const char * what)	roles:def	end:4
 find-found.c	src/find-found.c	1;"	kind:file	line:1	language:C	roles:def	extras:inputFile	end:10
+found	src/dummy.S	/^found:$/;"	kind:label	line:1	language:Asm	roles:def
 found	src/find-found.c	/^bool found()$/;"	kind:function	line:6	language:C	typeref:typename:bool	signature:()	roles:def	end:9
 found	src/goto-sorting.c	/^ found:$/;"	kind:label	line:8	language:C	scope:function:main	file:	roles:def	extras:fileScope
 game	src/game.h	/^struct game {$/;"	kind:struct	line:2	language:C++	roles:def	end:4

--- a/tests/ctags-lang-c/xref/goto-sorting/call.xref
+++ b/tests/ctags-lang-c/xref/goto-sorting/call.xref
@@ -1,4 +1,6 @@
 src/find-found.c
 6: (function/bool) bool found()
+src/dummy.S
+1: (label) found:
 src/goto-sorting.c
 8: (label@function:main) found:

--- a/tests/ctags-lang-c/xref/goto-sorting/goto.xref
+++ b/tests/ctags-lang-c/xref/goto-sorting/goto.xref
@@ -1,4 +1,6 @@
 src/goto-sorting.c
 8: (label@function:main) found:
+src/dummy.S
+1: (label) found:
 src/find-found.c
 6: (function/bool) bool found()


### PR DESCRIPTION
"label" is a very popular kind name in ctags parsers:

$ ctags --list-kinds-full
Ada                  b      label                 yes     no      0      NONE   labels
Asm                  l      label                 yes     no      0      NONE   labels
Basic                l      label                 yes     no      0      NONE   labels
C                    L      label                 no      no      0      C      goto labels
C++                  L      label                 no      no      0      C      goto labels
CUDA                 L      label                 no      no      0      NONE   goto labels
DTS                  l      label                 yes     no      0      NONE   labels
DosBatch             l      label                 yes     no      0      NONE   labels
Fortran              l      label                 yes     no      0      NONE   labels
OldC                 L      label                 no      no      0      NONE   goto label
OldC++               L      label                 no      no      0      NONE   goto label
Perl                 l      label                 yes     no      0      NONE   labels
SQL                  L      label                 yes     no      0      NONE   block label
Tex                  l      label                 yes     no      0      NONE   labels
YACC                 l      label                 yes     no      0      NONE   labels

When sorting labels for goto, labels of C and C++ should
have higher priority.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>