### PR TITLE
common, add: async process infrastructure

### DIFF
--- a/citre-basic-tools.el
+++ b/citre-basic-tools.el
@@ -432,8 +432,7 @@ STR is a candidate in a capf session.  See the implementation of
       (let* ((cache citre-capf--cache)
              (file (buffer-file-name))
              (bounds (citre-get-property 'bounds symbol)))
-        (if (and citre-capf-optimize-for-popup
-                 (equal (plist-get cache :file) file)
+        (if (and (equal (plist-get cache :file) file)
                  (string-prefix-p (plist-get cache :symbol) symbol)
                  ;; We also need to make sure we are in the process of
                  ;; completing the same whole symbol, since same symbol in

--- a/citre-basic-tools.el
+++ b/citre-basic-tools.el
@@ -449,10 +449,12 @@ STR is a candidate in a capf session.  See the implementation of
           ;; Make sure we get a non-nil collection first, then setup the cache,
           ;; since the calculation can be interrupted by user input, and we get
           ;; nil, which aren't the actual completions.
-          (when-let ((citre-stop-process-on-input t)
-                     (completions
-                      (citre-get-completions
-                       symbol nil citre-capf-substr-completion))
+          (when-let ((completions
+                      (pcase (while-no-input
+                               (citre-get-completions
+                                symbol nil citre-capf-substr-completion))
+                        ('t nil)
+                        (val val)))
                      (collection
                       (pcase (while-no-input
                                (citre-capf--make-collection completions))

--- a/citre-core.el
+++ b/citre-core.el
@@ -231,7 +231,6 @@ any valid actions in readtags, e.g., \"-D\", to get pseudo tags."
                     ('prefix "p")
                     (_ (error "Unexpected value of MATCH")))
                   (if case-fold "i" "")))
-         (output-buf (get-buffer-create " *citre-readtags*"))
          (tagsfile (substring-no-properties tagsfile))
          (name (when name (substring-no-properties name)))
          (filter (citre-core--strip-text-property-in-list filter))
@@ -254,7 +253,7 @@ any valid actions in readtags, e.g., \"-D\", to get pseudo tags."
           (push "-l" cmd)
         (push "-" cmd)
         (push name cmd)))
-    (citre-get-output-lines (nreverse cmd) output-buf 'get-lines)))
+    (citre-get-output-lines (nreverse cmd))))
 
 ;;;;; Parse tagline
 

--- a/citre-global.el
+++ b/citre-global.el
@@ -152,8 +152,7 @@ message of global) start from START-FILE."
                            cmd))
     (setq cmd (append (nreverse cmd) citre-global--find-references-args
                       (list "--" name)))
-    (citre-get-output-lines cmd (get-buffer-create " *citre-global*")
-                            'get-lines)))
+    (citre-get-output-lines cmd)))
 
 (defun citre-global--read-path (path)
   "Translate escaped sequences in PATH.

--- a/tests/common-process/test.el
+++ b/tests/common-process/test.el
@@ -1,0 +1,93 @@
+;; Process infrastructure tests
+
+;;; Helper function
+
+(defun poll-process (citre-proc)
+  "Poll for citre-process CITRE-PROC."
+  (let ((proc (citre-process-proc citre-proc))
+        (stderr-buffer (citre-process-stderr-buffer citre-proc))
+        stderr-proc)
+    (while (accept-process-output proc))
+    (when (and (buffer-live-p stderr-buffer)
+               (setq stderr-proc (get-buffer-process stderr-buffer)))
+      (while (accept-process-output stderr-proc)))))
+
+;;; Async process
+
+(ert-deftest test-async-process-output ()
+  "Test output handling of async processes."
+  (let* ((success nil)
+         (output "")
+         (callback (lambda (status msg)
+                     (pcase status
+                       ('output (setq output (concat output msg)))
+                       (0 nil)
+                       (s (error (format "Status %s shouldn't occur" s))))))
+         (proc-data (citre-make-async-process
+                     '("sh" "-c" "sleep 0.1 && echo \"line 1\nline 2\"")
+                     callback)))
+    (poll-process proc-data)
+    (should (equal output "line 1\nline 2\n"))))
+
+(ert-deftest test-async-process-exit-0 ()
+  "Test handling of exit status 0 of async processes."
+  (let* ((success nil)
+         (callback (lambda (status msg)
+                     (pcase status
+                       ('output nil)
+                       (0 (should (equal msg nil)))
+                       (s (error (format "Status %s shouldn't occur" s))))))
+         (proc-data (citre-make-async-process
+                     '("sh" "-c" "sleep 0.1 && echo \"msg\" 1>&2 && exit 0")
+                     callback)))
+    (poll-process proc-data)))
+
+(ert-deftest test-async-process-exit-1 ()
+  "Test handling of exit status 0 of async processes."
+  (let* ((success nil)
+         (callback (lambda (status msg)
+                     (pcase status
+                       ('output nil)
+                       ;; I think this may fail when there's large chunks of
+                       ;; output to stderr.
+                       (1 (should (equal msg "msg\n")))
+                       (s (error (format "Status %s shouldn't occur" s))))))
+         (proc-data (citre-make-async-process
+                     '("sh" "-c" "sleep 0.1 & echo \"msg\" 1>&2 && exit 1")
+                     callback)))
+    (poll-process proc-data)))
+
+(ert-deftest test-async-process-signal ()
+  "Test signal handling of async processes."
+  (let* ((success nil)
+         (callback (lambda (status msg)
+                     (should (eq status 'signal))))
+         (proc-data (citre-make-async-process '("sh" "-c" "sleep 1")
+                                              callback)))
+    (sleep-for 0.1)
+    (interrupt-process (citre-process-proc proc-data))))
+
+;;; Synchronous process
+
+(ert-deftest test-synchronous-process-output ()
+  "Test output handling of synchronous processes."
+  (should (equal (citre-get-output-lines
+                  '("sh" "-c" "sleep 0.1 && echo \"line 1\nline 2\""))
+                 '("line 1" "line 2"))))
+
+(ert-deftest test-synchronous-process-exit-1 ()
+  "Test synchronous processes that exit abnormally."
+  (should-error (citre-get-output-lines
+                 '("sh" "-c" "sleep 0.1 && exit 1"))))
+
+(ert-deftest test-synchronous-process-quit ()
+  "Test keyboard quit on synchronous processes."
+  (run-at-time 0.1 nil (lambda () (keyboard-quit)))
+  (let ((inhibit-quit t)
+        (start-time (current-time))
+        end-time)
+    (with-local-quit
+      (citre-get-output-lines
+       '("sh" "-c" "sleep 1")))
+    (should (< (time-to-seconds (time-since start-time)) 0.5))
+    (setq quit-flag nil)))


### PR DESCRIPTION
Async process infrastructure is added so we have a basis for interactively inspecting a tags file, which is a planned future feature.

The synchronous process interface is also rewritten based on this. It's cleaner than the previous implementation, and hopefully could solve process related problems on Windows, which I constantly get complaints about from other forums.

Recently some users reported that Citre doesn't work with [corfu]() on Windows. They constantly get the error:

```
error in process sentinel: No catch for tag: citre-done, t
```

I'll invite them to test this.