### PR TITLE
util,fix: don't exclude input file names from definition lists

### DIFF
--- a/citre-util.el
+++ b/citre-util.el
@@ -561,7 +561,6 @@ completion can't be done."
        ;; Don't excluded "anonymous" here as such symbols can appear in typeref
        ;; or scope fields of other tags, which may be shown in an xref buffer,
        ;; so we should be able to find their definitions.
-       ,citre-filter-file-tags
        ,(if file-path
             (citre-filter-local-symbol-in-other-file file-path tags-file)
           'false)))))


### PR DESCRIPTION
Close #131.

The input file names were excluded unintentionally.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>