### PR TITLE
add bypass update tagsfile feature

### DIFF
--- a/citre-ctags.el
+++ b/citre-ctags.el
@@ -481,7 +481,7 @@ See *citre-ctags* buffer" s))))
         (message "Updating %s..." tagsfile))
       t)))
 
-(defun citre-get-definitions-maybe-update-tags-file (&optional symbol tagsfile)
+(defun citre-get-definitions-maybe-update-tags-file (&optional symbol tagsfile  no-update)
   "Get definitions of SYMBOL from TAGSFILE.
 When the definitions are not found, and
 `citre-update-tags-file-when-no-definitions' is non-nil, update
@@ -492,7 +492,7 @@ See `citre-get-definitions' to know the behavior of \"getting
 definitions\"."
   (let ((tagsfile (or tagsfile (citre-tags-file-path))))
     (or (citre-get-definitions symbol tagsfile)
-        (when (and citre-update-tags-file-when-no-definitions
+        (when (and citre-update-tags-file-when-no-definitions (not no-update)
                    (citre-tags-file-updatable-p tagsfile)
                    (y-or-n-p "Can't find definition.  \
 Update the tags file and search again? "))


### PR DESCRIPTION
I need to use the definition result returned by the function citre-get-definitions-maybe-update-tags-file to display the definition of the symbol at the cursor below the minibuffer. Often some symbols cannot be found in the tagsfile, and every time to choose very unfriendly

![image](https://user-images.githubusercontent.com/19771608/191402764-736c83e2-fc0c-448c-81c3-e6e3a911e336.png)
