### PR TITLE
tags: warn if citre-locate-tag fails to find regexp within search-limit

### DIFF
--- a/citre-common-tag.el
+++ b/citre-common-tag.el
@@ -719,6 +719,11 @@ the position of a tag."
               (citre-find-nearest-regexp
                (concat pat-beg (rx (* space)) (regexp-quote (string-trim str)))
                lim 'case-fold))))
+         ;; Warn if the buffer size is larger than the search limit. Fall
+         ;; through to search for the tag name.
+         (and nil (when (> (buffer-size) citre-tag-pattern-search-limit)
+                    (message (concat "regexp not found but the buffer size is larger than "
+                                     "citre-tag-pattern-search-limit; consider increasing it."))))
          ;; Last try: search for the tag name.
          (when name
            (or


### PR DESCRIPTION
It'd be nice to warn the user the attempt to locate the tag by regexp has failed probably due to the search limit; otherwise it's quite confusing to have the buffer ending up with: 
* the point on the first occurrence of the name (a hit on the name only within the search-limit). It could be among some random comment text. 
* the point in the beginning of the buffer (no hit at all on the name only within the search-limit).
