### PR TITLE
Don't signal an error when Global database isn't found

### DIFF
--- a/citre.el
+++ b/citre.el
@@ -501,9 +501,10 @@ The returned value is a valid return value for
   (if-let ((buf (citre-get-property 'xref-symbol-buffer symbol)))
       (with-current-buffer buf
         (citre-xref--make-collection (citre-get-references)))
-    (prog1 nil ; return nil so `xref' can try other backends
-      (message "Finding references of completed symbol is not supported \
-by Citre"))))
+    (message "Finding references of completed symbol is not supported by \
+Citre")
+    ;; return nil so `xref' can try other backends
+    nil))
 
 ;;;; Imenu
 

--- a/citre.el
+++ b/citre.el
@@ -501,8 +501,9 @@ The returned value is a valid return value for
   (if-let ((buf (citre-get-property 'xref-symbol-buffer symbol)))
       (with-current-buffer buf
         (citre-xref--make-collection (citre-get-references)))
-    (user-error "Finding references of completed symbol is not supported \
-by Citre")))
+    (prog1 nil ; return nil so `xref' can try other backends
+      (message "Finding references of completed symbol is not supported \
+by Citre"))))
 
 ;;;; Imenu
 


### PR DESCRIPTION
First, thank you for this excellent package and for maintaining Universal Ctags!

This MR disables signaling an error when `citre` `xref` backend for `find-references` fails. This is useful when we have other backends configured for a project (like `dumb-jump` for example).

Also, this can be useful when several backends are merged using `xref-union` 