### PR TITLE
Don't add `--objdir` unless the required environment variable is set

### DIFF
--- a/citre-global.el
+++ b/citre-global.el
@@ -62,7 +62,13 @@ Set this if global is not in your PATH, or its name is not
                  (const :tag "global" nil))
   :group 'citre)
 
-(defcustom citre-gtags-args '("--compact" "--objdir")
+(defcustom citre-gtags-args `("--compact"
+                              ;; The "--objdir" option isn't valid unless one
+                              ;; of "MAKEOBJDIRPREFIX" or "GTAGSOBJDIRPREFIX"
+                              ;; is set as an environment variable.
+                              ,@(when (or (getenv "MAKEOBJDIRPREFIX")
+                                          (getenv "GTAGSOBJDIRPREFIX"))
+                                  '("--objdir")))
   "Arguments for running gtags.
 On Windows, the \"--objdir\" argument may cause \"Objdir not
 found\" error.  If this happens, you need to customize this


### PR DESCRIPTION
When the `MAKEOBJDIRPREFIX` or `GTAGSOBJDIRPREFIX` environment variables aren't defined, the `--objdir` option causes `gtags` to fail.

This change checks if the required environment variables are set before setting this as a default. This will fix the problem of `gtags` failing when using the default `citre-gtags-args` in case the variables aren't defined.